### PR TITLE
Remove ununsed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.0",
-    "dotenv": "^8.2.0",
     "jsonwebtoken": "^8.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,11 +1,10 @@
 import React, { Suspense, lazy } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import GlobalStyles from './global-styles';
-import dotenv from 'dotenv';
 const WidgetCreator = lazy(() => import('./widget-creator'));
 const Widget = lazy(() => import('./widget'));
 const NotFound = lazy(() => import('./not-found'));
-dotenv.config();
+
 function App() {
   return (
     <Suspense fallback={<p>Loading page...</p>}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3868,7 +3868,7 @@ dotenv-expand@5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv@8.2.0, dotenv@^8.2.0:
+dotenv@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
This PR removes the unused packages from the project dependencies.

* `dotenv` - This package is not required as React itself provides the support for the environment variables. 